### PR TITLE
Fix multi-edito on GuidReferenceDrawer

### DIFF
--- a/Assets/CrossSceneReference/Editor/GuidReferenceDrawer.cs
+++ b/Assets/CrossSceneReference/Editor/GuidReferenceDrawer.cs
@@ -15,8 +15,6 @@ public class GuidReferenceDrawer : PropertyDrawer
     GUIContent sceneLabel = new GUIContent("Containing Scene", "The target object is expected in this scene asset.");
     GUIContent clearButtonGUI = new GUIContent("Clear", "Remove Cross Scene Reference");
 
-    bool cached = false;
-
     // add an extra line to display source scene for targets
     public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
     {
@@ -25,15 +23,10 @@ public class GuidReferenceDrawer : PropertyDrawer
 
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
     {
-        // cache off properties, as find can be slow
-        if (!cached)
-        {
-            guidProp = property.FindPropertyRelative("serializedGuid");
-            nameProp = property.FindPropertyRelative("cachedName");
-            sceneProp = property.FindPropertyRelative("cachedScene");
-
-            cached = true;
-        }
+       
+        guidProp = property.FindPropertyRelative("serializedGuid");
+        nameProp = property.FindPropertyRelative("cachedName");
+        sceneProp = property.FindPropertyRelative("cachedScene");
 
         // Using BeginProperty / EndProperty on the parent property means that
         // prefab override logic works on the entire property.

--- a/Assets/CrossSceneReference/Runtime/GuidReference.cs
+++ b/Assets/CrossSceneReference/Runtime/GuidReference.cs
@@ -89,6 +89,10 @@ public class GuidReference : ISerializationCallbackReceiver
     {
         cachedReference = null;
         isCacheSet = false;
+        if (serializedGuid == null || serializedGuid.Length != 16)
+        {
+            serializedGuid = new byte[16];
+        }
         guid = new System.Guid(serializedGuid);
         addDelegate = GuidAdded;
         removeDelegate = GuidRemoved;


### PR DESCRIPTION
Pre-mature optimization caused the cached Property references to stick around when drawing lists of GuidReferences