### PR TITLE
Mark Scene as dirty when Guid is created.

### DIFF
--- a/Assets/CrossSceneReference/Runtime/GuidComponent.cs
+++ b/Assets/CrossSceneReference/Runtime/GuidComponent.cs
@@ -31,6 +31,7 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
             serializedGuid = guid.ToByteArray();
 
 #if UNITY_EDITOR
+            UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(gameObject.scene);
             // If we are creating a new GUID for a prefab instance of a prefab, but we have somehow lost our prefab connection
             // force a save of the modified prefab instance properties
             PrefabType prefabType = PrefabUtility.GetPrefabType(this);
@@ -90,7 +91,7 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
         }
     }
 
-    void Awake()
+    void Start()
     {
         CreateGuid();
     }
@@ -109,7 +110,10 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
         else
 #endif
         {
-            CreateGuid();
+            if (!gameObject.scene.IsValid() || gameObject.scene.isLoaded)
+            {
+                CreateGuid();
+            }
         }
     }
 


### PR DESCRIPTION
This is especially useful when adding a GuidComponent on an existing prefab that is already present in scenes.

This does not allow the user to undo. This is desired. A user shouldn't be able to undo the Guid generation.

Important info: After the scene loading is complete, the scene dirtyness is cleared.
->
* CreateGuid() is moved from Awake to Start because at Awake, the scene is not considered as loaded.
* In OnValidate, first make sure that the scene is loaded before creating a new Guid.
  If the scene isn't loaded yet, Start will be called and that's enough.
  If we don't have a valid scene it means we are in a prefab.
  In that case, guid should be empty, but it doesn't hurt to have a fallback for any unforseen case.

Extra information to back up my statements:
* OnValidate is done during loading: https://issuetracker.unity3d.com/issues/markscenedirty-and-markallscenesdirty-does-not-work-when-called-in-onvalidate
* Awake is called before loading is complete: https://issuetracker.unity3d.com/issues/scene-is-not-considered-loaded-when-awake-is-called (note that it was supposed to be fixed in 2017.2.0f3, I'm on 2018.3.5f1 and it's still occuring)

Fixes #8