### PR TITLE
Unity 2018.3 API support (with compiler arguments for old API)

### DIFF
--- a/Assets/CrossSceneReference/Runtime/GuidComponent.cs
+++ b/Assets/CrossSceneReference/Runtime/GuidComponent.cs
@@ -34,7 +34,7 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
             // If we are creating a new GUID for a prefab instance of a prefab, but we have somehow lost our prefab connection
             // force a save of the modified prefab instance properties
 	#if UNITY_2018_3_OR_NEWER
-            if (PrefabUtility.IsPartOfPrefabInstance(this))
+            if (PrefabUtility.IsPartOfNonAssetPrefabInstance(this))
 	#else
             PrefabType prefabType = PrefabUtility.GetPrefabType(this);
             if (prefabType == PrefabType.PrefabInstance)
@@ -70,8 +70,7 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
         // This lets us detect if we are a prefab instance or a prefab asset.
         // A prefab asset cannot contain a GUID since it would then be duplicated when instanced.
 	#if UNITY_2018_3_OR_NEWER
-        PrefabAssetType prefabAssetType = PrefabUtility.GetPrefabAssetType(this);
-		if (prefabAssetType == PrefabAssetType.Regular || prefabAssetType == PrefabAssetType.Model)
+        if (PrefabUtility.IsPartOfPrefabAsset(this))
 	#else
         PrefabType prefabType = PrefabUtility.GetPrefabType(this);
         if (prefabType == PrefabType.Prefab || prefabType == PrefabType.ModelPrefab)
@@ -110,8 +109,7 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
         // similar to on Serialize, but gets called on Copying a Component or Applying a Prefab
         // at a time that lets us detect what we are
 	#if UNITY_2018_3_OR_NEWER
-        PrefabAssetType prefabAssetType = PrefabUtility.GetPrefabAssetType(this);
-		if (prefabAssetType == PrefabAssetType.Regular || prefabAssetType == PrefabAssetType.Model)
+        if (PrefabUtility.IsPartOfPrefabAsset(this) )
 	#else
 		PrefabType prefabType = PrefabUtility.GetPrefabType(this);
         if (prefabType == PrefabType.Prefab || prefabType == PrefabType.ModelPrefab)

--- a/Assets/CrossSceneReference/Runtime/GuidComponent.cs
+++ b/Assets/CrossSceneReference/Runtime/GuidComponent.cs
@@ -33,7 +33,12 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
 #if UNITY_EDITOR
             // If we are creating a new GUID for a prefab instance of a prefab, but we have somehow lost our prefab connection
             // force a save of the modified prefab instance properties
+	#if UNITY_2018_3_OR_NEWER
             if (PrefabUtility.IsPartOfPrefabInstance(this))
+	#else
+            PrefabType prefabType = PrefabUtility.GetPrefabType(this);
+            if (prefabType == PrefabType.PrefabInstance)
+	#endif
             {
                 PrefabUtility.RecordPrefabInstancePropertyModifications(this);
             }
@@ -64,8 +69,13 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
 #if UNITY_EDITOR
         // This lets us detect if we are a prefab instance or a prefab asset.
         // A prefab asset cannot contain a GUID since it would then be duplicated when instanced.
+	#if UNITY_2018_3_OR_NEWER
         PrefabAssetType prefabAssetType = PrefabUtility.GetPrefabAssetType(this);
 		if (prefabAssetType == PrefabAssetType.Regular || prefabAssetType == PrefabAssetType.Model)
+	#else
+        PrefabType prefabType = PrefabUtility.GetPrefabType(this);
+        if (prefabType == PrefabType.Prefab || prefabType == PrefabType.ModelPrefab)
+	#endif
         {
             serializedGuid = new byte[0];
             guid = System.Guid.Empty;
@@ -99,8 +109,13 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
 #if UNITY_EDITOR
         // similar to on Serialize, but gets called on Copying a Component or Applying a Prefab
         // at a time that lets us detect what we are
+	#if UNITY_2018_3_OR_NEWER
         PrefabAssetType prefabAssetType = PrefabUtility.GetPrefabAssetType(this);
 		if (prefabAssetType == PrefabAssetType.Regular || prefabAssetType == PrefabAssetType.Model)
+	#else
+		PrefabType prefabType = PrefabUtility.GetPrefabType(this);
+        if (prefabType == PrefabType.Prefab || prefabType == PrefabType.ModelPrefab)
+	#endif
         {
             serializedGuid = null;
             guid = System.Guid.Empty;

--- a/Assets/CrossSceneReference/Runtime/GuidComponent.cs
+++ b/Assets/CrossSceneReference/Runtime/GuidComponent.cs
@@ -33,8 +33,7 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
 #if UNITY_EDITOR
             // If we are creating a new GUID for a prefab instance of a prefab, but we have somehow lost our prefab connection
             // force a save of the modified prefab instance properties
-            PrefabType prefabType = PrefabUtility.GetPrefabType(this);
-            if (prefabType == PrefabType.PrefabInstance)
+            if (PrefabUtility.IsPartOfPrefabInstance(this))
             {
                 PrefabUtility.RecordPrefabInstancePropertyModifications(this);
             }
@@ -65,8 +64,8 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
 #if UNITY_EDITOR
         // This lets us detect if we are a prefab instance or a prefab asset.
         // A prefab asset cannot contain a GUID since it would then be duplicated when instanced.
-        PrefabType prefabType = PrefabUtility.GetPrefabType(this);
-        if (prefabType == PrefabType.Prefab || prefabType == PrefabType.ModelPrefab)
+        PrefabAssetType prefabAssetType = PrefabUtility.GetPrefabAssetType(this);
+		if (prefabAssetType == PrefabAssetType.Regular || prefabAssetType == PrefabAssetType.Model)
         {
             serializedGuid = new byte[0];
             guid = System.Guid.Empty;
@@ -100,8 +99,8 @@ public class GuidComponent : MonoBehaviour, ISerializationCallbackReceiver
 #if UNITY_EDITOR
         // similar to on Serialize, but gets called on Copying a Component or Applying a Prefab
         // at a time that lets us detect what we are
-        PrefabType prefabType = PrefabUtility.GetPrefabType(this);
-        if (prefabType == PrefabType.Prefab || prefabType == PrefabType.ModelPrefab)
+        PrefabAssetType prefabAssetType = PrefabUtility.GetPrefabAssetType(this);
+		if (prefabAssetType == PrefabAssetType.Regular || prefabAssetType == PrefabAssetType.Model)
         {
             serializedGuid = null;
             guid = System.Guid.Empty;

--- a/Assets/CrossSceneReference/Tests/Editor/GuidReferenceTests.cs
+++ b/Assets/CrossSceneReference/Tests/Editor/GuidReferenceTests.cs
@@ -25,7 +25,12 @@ public class GuidReferenceTests
         prefabPath = "Assets/TemporaryTestGuid.prefab";
 
         guidBase = CreateNewGuid();
+		
+#if UNITY_2018_3_OR_NEWER
 		prefab = PrefabUtility.SaveAsPrefabAsset(guidBase.gameObject, prefabPath);
+#else
+        prefab = PrefabUtility.CreatePrefab(prefabPath, guidBase.gameObject);
+#endif
 
         guidPrefab = prefab.GetComponent<GuidComponent>();
     }

--- a/Assets/CrossSceneReference/Tests/Editor/GuidReferenceTests.cs
+++ b/Assets/CrossSceneReference/Tests/Editor/GuidReferenceTests.cs
@@ -25,7 +25,7 @@ public class GuidReferenceTests
         prefabPath = "Assets/TemporaryTestGuid.prefab";
 
         guidBase = CreateNewGuid();
-        prefab = PrefabUtility.CreatePrefab(prefabPath, guidBase.gameObject);
+		prefab = PrefabUtility.SaveAsPrefabAsset(guidBase.gameObject, prefabPath);
 
         guidPrefab = prefab.GetComponent<GuidComponent>();
     }


### PR DESCRIPTION
(First, sorry about my tabs)

This is a relatively straightforward API update, except that due to the new Prefab structure there is no replacement for `PrefabType.PrefabInstance`. I'm a little worried that `PrefabUtility.IsPartOfPrefabInstance(this)`, which I use here, might not be the correct way to fully capture the same functionality, or may introduce unintended functionality.

I used compiler arguments so that it would remain compatible with pre-2018.3 projects.

(I love this project, by the way. I use it to easilty keep track of the status/position of thousands of objects across all the scenes my game in order to automatically populate data into my player's save file.)